### PR TITLE
fixed php8 issue

### DIFF
--- a/hideactivitytypes.php
+++ b/hideactivitytypes.php
@@ -148,6 +148,7 @@ function hideactivitytypes_civicrm_tabset($tabsetName, &$tabs, $context) {
         ->setCheckPermissions(FALSE)
         ->execute();
       //Collect Contact Types and Subtypes
+      $types = [];
       foreach ($contacts as $contact) {
         $types[] = $contact['contact_type'];
         if (is_array($contact['contact_sub_type'])) {


### PR DESCRIPTION
Error: 

Fatal error: Uncaught TypeError: array_unique(): Argument #1 ($array) must be of type array, null given in /home/wordpress/wp-content/uploads/civicrm/ext/contrib/hideactivitytypes/hideactivitytypes.php:160